### PR TITLE
Swagger docs up and running babyyyy!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -2,3 +2,8 @@ spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
+
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
Use the command `docker compose up --build` to rebuild project. Once the project is up and running, you can access docs via http://localhost:8080/swagger-ui/index.html

fixes #25 